### PR TITLE
Download data from NSIDC DAAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Developers and users must set the following environment variables:
 ### Directory Structure
 These variables will be ready by the configuration file. If the directories do not exist they will be created for you at runtime.
 ##### `INPUT_DIR`
-Set to a path where you will download input data from NSIDC. Anticpate needing 10GB disk space per year for the full AK domain. Something like:
+Set to a path where you will download input data from NSIDC. Anticpate needing around 10GB disk space per year for the full AK domain. For a production run there are 82,003 granules of VNP10A1F version 2 totaling ~192 GB, so the download directory (`INPUT_DIR`) needs at least 200 GB free space for a full run. Example:
 ```sh
 export INPUT_DIR=/big_imaginary_disks/VIIRS_L3_snow_cover
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Placeholder: `conda env` setup instructions
 
 Developers and users must set the following environment variables:
 ### Directory Structure
-These variables will be ready by the configuration file. If the directories do not exist they will be created for you at runtime.
+These variables will be read by the configuration file. If the directories do not exist they will be created for you at runtime.
 ##### `INPUT_DIR`
 Set to a path where you will download input data from NSIDC. Anticpate needing around 10GB disk space per year for the full AK domain. For a production run there are 82,003 granules of VNP10A1F version 2 totaling ~192 GB, so the download directory (`INPUT_DIR`) needs at least 200 GB free space for a full run. Example:
 ```sh
@@ -30,7 +30,9 @@ export DEV_MODE=True
 
 ## Usage
 ### `download.py`
-Run this script with no arguments to download the source dataset from the NSIDC DAAC. Users will be prompted to enter valid Earthdata credentials. Users must have an Earthdata account to download the necessary data. Data will be downloaded to the `$INPUT_DIR` directory. Total download time will of course depend on your connection speed, but it will also depend on how busy the upstream data service is and how complicated your data orders[] are. For example, if you are asking the service to perform reformatting (e.g., h5 format to GeoTIFF)[https://nsidc.org/data/user-resources/help-center/table-key-value-pair-kvp-operands-subsetting-reformatting-and-reprojection-services] the service will take longer to prepare the order. Consider executing `download.py` in a screen session or similar. It may take a full day to prepare the order for a download of the full time series, and the order preparation may take longer than the download itself. A log file will be written to the same directory as the downloaded data that captures the API endpoints used as well as information about the requested granules.
+Run this script with no arguments to download the source dataset from the NSIDC DAAC. Users will be prompted to enter valid Earthdata credentials. Users must have an Earthdata account to download the necessary data. Data will be downloaded to the `$INPUT_DIR` directory. The script will ask to wipe the contents of `$INPUT_DIR` before proceeding with the download. Total download time will of course depend on your connection speed, but it will also depend on how busy the upstream data service is and how complicated your data orders[] are. For example, if you are asking the service to perform [reformatting (e.g., h5 to GeoTIFF)](https://nsidc.org/data/user-resources/help-center/table-key-value-pair-kvp-operands-subsetting-reformatting-and-reprojection-services) the service will take longer to prepare the order. Consider executing `download.py` in a screen session or similar. It may take a full day to prepare the order for a download of the full time series, and the order preparation may take longer than the download itself. A log file (`download.log`) will be written to the same directory as the download script that captures the API endpoints used as well as information about the requested granules.
+#### Example Usage
+`python download.py`
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 # VIIRS Snow Metrics for Alaska
 
 ## Development Setup
-Placeholder: `conda env` setup instructions
+Create the conda environment from the `environment.yml` file if you have not done so already.
+```sh
+conda env create -f environment.yml
+```
+Activate the environment:
+```sh
+conda activate viirs-snow
+```
 
 Developers and users must set the following environment variables:
 ### Directory Structure

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These variables will be ready by the configuration file. If the directories do n
 ##### `INPUT_DIR`
 Set to a path where you will download input data from NSIDC. Anticpate needing around 10GB disk space per year for the full AK domain. For a production run there are 82,003 granules of VNP10A1F version 2 totaling ~192 GB, so the download directory (`INPUT_DIR`) needs at least 200 GB free space for a full run. Example:
 ```sh
-export INPUT_DIR=/big_imaginary_disks/VIIRS_L3_snow_cover
+export INPUT_DIR=/export/datadir/your_viirs_dir/VIIRS_L3_snow_cover
 ```
 ##### `SCRATCH_DIR`
 Set to the path where you will read/write preprocessed data prior to computation of the actual metrics. Something like:
@@ -27,5 +27,10 @@ Set to True (note this will be passed as a `string` type rather than `bool`) to 
 ```sh
 export DEV_MODE=True
 ```
+
+## Usage
+### `download.py`
+Run this script with no arguments to download the source dataset from the NSIDC DAAC. Users will be prompted to enter valid Earthdata credentials. Users must have an Earthdata account to download the necessary data. Data will be downloaded to the `$INPUT_DIR` directory. Total download time will of course depend on your connection speed, but it will also depend on how busy the upstream data service is and how complicated your data orders[] are. For example, if you are asking the service to perform reformatting (e.g., h5 format to GeoTIFF)[https://nsidc.org/data/user-resources/help-center/table-key-value-pair-kvp-operands-subsetting-reformatting-and-reprojection-services] the service will take longer to prepare the order. Consider executing `download.py` in a screen session or similar. It may take a full day to prepare the order for a download of the full time series, and the order preparation may take longer than the download itself. A log file will be written to the same directory as the downloaded data that captures the API endpoints used as well as information about the requested granules.
+
 
 

--- a/config.py
+++ b/config.py
@@ -32,11 +32,10 @@ else:
     DEV_MODE = True
 
 if not DEV_MODE:
-    params = parameter_sets["prod_params"]
+    viirs_params = parameter_sets["prod_params"]
     print("Operating in production mode with the following parameters:")
-    print(params)
+    print(viirs_params)
 else:
-    params = parameter_sets["dev_params"]
+    viirs_params = parameter_sets["dev_params"]
     print("Operating in development mode with the following parameters:")
-    print(params)
-
+    print(viirs_params)

--- a/download.py
+++ b/download.py
@@ -1,0 +1,38 @@
+"""Download VIIRS Data from the NSIDC DAAC"""
+
+import requests
+import getpass
+import socket 
+import json
+import zipfile
+import io
+import math
+import os
+import shutil
+import pprint
+import re
+import time
+from requests.auth import HTTPBasicAuth
+
+from luts import short_name
+
+
+# def start_api_session():
+#     """This function initates as NSDIC DAAC API session."""
+    
+
+#     capability_url = f'https://n5eil02u.ecs.nsidc.org/egi/capabilities/{short_name}.{latest_version}.xml'
+
+#     # Create session to store cookie and pass credentials to capabilities url
+#     session = requests.session()
+#     s = session.get(capability_url)
+#     response = session.get(s.url,auth=(uid,pswd))
+#     return response
+
+if __name__ == "__main__":
+    # Earthdata credentials
+    uid = input("Earthdata Login user name: ")
+    pswd = getpass.getpass("Earthdata Login password: ")
+    #start_api_session()
+
+    base_request_url = f"https://n5eil02u.ecs.nsidc.org/egi/request?short_name=VNP10A1F&version=2&temporal=2013-01-01T00%3A00%3A00Z%2C2014-12-31T00%3A00%3A00Z&bounding_box=-146%2C64%2C-144%2C66&bbox=-146%2C64%2C-144%2C66&format=GeoTIFF&projection=GEOGRAPHIC&page_size=2000&request_mode=async&page_num=1"

--- a/download.py
+++ b/download.py
@@ -363,7 +363,7 @@ def validate_download(dl_path, number_granules_requested):
     dl_files_expected = number_granules_requested * n_variables
     logging.info(f"{dl_file_count} files were downloaded.")
     if dl_file_count != dl_files_expected:
-        logging.warn(
+        logging.warning(
             f"{dl_file_count} files were downloaded, but based on {number_granules_requested} granules a downloaded file count of {dl_files_expected} is expected."
         )
     else:

--- a/download.py
+++ b/download.py
@@ -12,11 +12,13 @@ import shutil
 import pprint
 import re
 import time
+import logging
 from requests.auth import HTTPBasicAuth
 from statistics import mean
+from xml.etree import ElementTree as ET
 
 from luts import short_name
-from config import viirs_params
+from config import viirs_params, INPUT_DIR
 
 # Class API session
 # version
@@ -28,7 +30,7 @@ from config import viirs_params
 def check_data_version(ds_short_name):
     """Get latest version number of the dataset."""
     cmr_collections_url = "https://cmr.earthdata.nasa.gov/search/collections.json"
-    response = requests.get(cmr_collections_url, params={"short_name": short_name})
+    response = requests.get(cmr_collections_url, params={"short_name": ds_short_name})
     results = json.loads(response.content)
 
     # find all instances of 'version_id' in metadata
@@ -48,12 +50,12 @@ def start_api_session(ds_short_name, ds_latest_version):
     session = requests.session()
     s = session.get(capability_url)
     response = session.get(s.url, auth=(uid, pswd))
-    return response
+    logging.info(response)
+    return session
 
 
 def search_granules(ds_latest_version, ds_short_name, tstart, tstop, bbox):
     """Search for granules within a time range and geographic bounding box. API reference: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#query-parameters"""
-    # Create CMR parameters used for granule search. Modify params depending on bounding_box or polygon input.
 
     granule_search_url = "https://cmr.earthdata.nasa.gov/search/granules"
     search_params = {
@@ -72,7 +74,6 @@ def search_granules(ds_latest_version, ds_short_name, tstart, tstop, bbox):
             granule_search_url, params=search_params, headers=headers
         )
         results = json.loads(response.content)
-        print(results)
         if len(results["feed"]["entry"]) == 0:
             # Out of results, so break out of loop
             break
@@ -81,27 +82,205 @@ def search_granules(ds_latest_version, ds_short_name, tstart, tstop, bbox):
         granules.extend(results["feed"]["entry"])
         search_params["page_num"] += 1
 
-    print(
+    logging.info(
         f"{len(granules)} granules of {ds_short_name} version {ds_latest_version} cover your area and time of interest."
     )
 
     granule_sizes = [float(granule["granule_size"]) for granule in granules]
 
-    print(
+    logging.info(
         f"The average size of each granule is {mean(granule_sizes):.2f} MB and the total size of all {len(granules)} granules is {sum(granule_sizes):.2f} MB"
     )
+    # CP commenting out because this is well, very granular
+    # logging.info(results)
+    return granules
+
+
+def set_n_orders_and_mode_and_page_size(granules):
+    """Determine number of orders (endpoints) required based on number of granules requested. Requests will nearly always be async with the maximum page size (2000) but smaller dev chunks may benefit from synchronous requests and smaller page sizes."""
+
+    def set_request_mode(granules):
+        """Request data asynchronously or synchronously based on number of granules. The API has some built in limits on synchronous requests."""
+        if len(granules) > 100:
+            request_mode = "async"
+        else:
+            request_mode = "stream"
+        return request_mode
+
+    def set_page_size(granules):
+        """Set page size (granule chunk size) for an individual API request."""
+        if len(granules) > 100:
+            page_size = 2000
+        else:
+            page_size = 100
+        return page_size
+
+    page_size = set_page_size(granules)
+    page_num = math.ceil(len(granules) / page_size)
+    request_mode = set_request_mode(granules)
+    return page_num, request_mode, page_size
+
+
+def construct_request(
+    ds_latest_version, ds_short_name, tstart, tstop, bbox, req_mode, pg_size
+):
+    """Construct the API Download Request."""
+    base_url = "https://n5eil02u.ecs.nsidc.org/egi/request"
+
+    dl_param_dict = {
+        "short_name": ds_short_name,
+        "version": ds_latest_version,
+        "temporal": f"{tstart},{tstop}",
+        "bounding_box": bbox,
+        "format": "GeoTIFF",  # NetCDF4-CF also viable, though failed to return data in an early test
+        "projection": "GEOGRAPHIC",
+        "page_size": pg_size,
+        "request_mode": req_mode,
+        "agent": "",  # may need to retain empty string value
+    }
+
+    # Convert to string: could use urllib quote - but will follow NSIDC example
+    dl_string = "&".join("{!s}={!r}".format(k, v) for (k, v) in dl_param_dict.items())
+    dl_string = dl_string.replace("'", "")
+
+    # Construct request URL(s)
+    endpoint_list = []
+    for i in range(page_num):
+        page_val = i + 1
+        api_request = f"{base_url}?{dl_string}&page_num={page_val}"
+        endpoint_list.append(api_request)
+
+    logging.info(*endpoint_list)
+    # we may not end up needing the list of endpoints, as the ordering function can use the dl_param_dict to construct the orders, in that case we wouldn't return them, but log them for reference or sharing
+    return endpoint_list, dl_param_dict
+
+
+def wipe_old_downloads():
+    # probably want to wipe previously downloaded data if there
+    # check nws-drought repo maybe for example
+    # maybe ask user to confirm
+    return None
+
+
+def make_async_data_orders(n_orders, session, dl_param_dict):
+    # make the download 'orders' because the API will need to verify the order and do some processing before making it ready for download
+    # we have to pass an authenticated session to the scope of this function
+
+    base_url = "https://n5eil02u.ecs.nsidc.org/egi/request"
+    # Request data service for each page number i.e. order
+    for i in range(n_orders):
+        page_val = i + 1
+        logging.info(f"Order: {page_val}")
+
+        dl_param_dict["page_num"] = page_val
+        request = session.get(base_url, params=dl_param_dict)
+        logging.info(f"Request HTTP response: {request.status_code}")
+
+        # raise bad request: Loop will stop for bad response code.
+        request.raise_for_status()
+        logging.info(f"Order request URL: {request.url}")
+        esir_root = ET.fromstring(request.content)
+        logging.info(f"Order request response XML content: {request.content}")
+
+        # Look up order ID
+        orderlist = []
+        for order in esir_root.findall("./order/"):
+            orderlist.append(order.text)
+        orderID = orderlist[0]
+        logging.info(f"order ID: {orderID}")
+
+        # Create status URL
+        statusURL = base_url + "/" + orderID
+        logging.info(f"status URL: {statusURL}")
+
+        # Find order status
+        request_response = session.get(statusURL)
+        logging.info(
+            f"Status code from order response URL is {request_response.status_code}"
+        )
+
+        # Raise bad request: Loop will stop for bad response code.
+        request_response.raise_for_status()
+        request_root = ET.fromstring(request_response.content)
+        statuslist = []
+        for status in request_root.findall("./requestStatus/"):
+            statuslist.append(status.text)
+        status = statuslist[0]
+        logging.info(f"Data request {page_val} is submitting...")
+        logging.info(f"Initial request status is {status}")
+
+        # Continue loop while request is still processing
+        while status == "pending" or status == "processing":
+            logging.info("Status is not complete. Trying again.")
+            time.sleep(30)  # emit status twice per minute
+            loop_response = session.get(statusURL)
+
+            # Raise bad request: Loop will stop for bad response code.
+            loop_response.raise_for_status()
+            loop_root = ET.fromstring(loop_response.content)
+
+            # find status
+            statuslist = []
+            for status in loop_root.findall("./requestStatus/"):
+                statuslist.append(status.text)
+            status = statuslist[0]
+            print(status)
+            logging.info(f"Retry request status is {status}")
+            if status == "pending" or status == "processing":
+                continue
+
+        # Order can either complete, complete_with_errors, or fail:
+        if status == "complete_with_errors" or status == "failed":
+            logging.error("Order error messages:")
+            for message in loop_root.findall("./processInfo/"):
+                logging.error(message)
+
+        # Download zipped order if status is complete or complete_with_errors
+        if status == "complete" or status == "complete_with_errors":
+            download_url = "https://n5eil02u.ecs.nsidc.org/esir/" + orderID + ".zip"
+            logging.info(f"Zip download URL: {download_url}")
+            return download_url
+        else:
+            logging.error("Request failed.")
+
+
+# def download_order(download_url):
+#         logging.info("Beginning download of zipped output...")
+#         zip_response = session.get(download_url)
+#         # Raise bad request: Loop will stop for bad response code.
+#         zip_response.raise_for_status()
+#         with zipfile.ZipFile(io.BytesIO(zip_response.content)) as z:
+#             z.extractall(path)
+#         logging.info("Data request", page_val, "is complete.")  # log this
 
 
 if __name__ == "__main__":
+    logging.basicConfig(filename="download.log", level=logging.INFO)
     v = check_data_version(short_name)
-    r = start_api_session(short_name, v)
-    print(r)
-    search_granules(
+    api_session = start_api_session(short_name, v)
+    # bail if session fails
+    granule_list = search_granules(
         v,
         short_name,
         viirs_params["start_date"],
         viirs_params["end_date"],
         viirs_params["bbox"],
     )
-
-    base_request_url = f"https://n5eil02u.ecs.nsidc.org/egi/request?short_name=VNP10A1F&version=2&temporal=2013-01-01T00%3A00%3A00Z%2C2014-12-31T00%3A00%3A00Z&bounding_box=-146%2C64%2C-144%2C66&bbox=-146%2C64%2C-144%2C66&format=GeoTIFF&projection=GEOGRAPHIC&page_size=2000&request_mode=async&page_num=1"
+    page_num, request_mode, page_size = set_n_orders_and_mode_and_page_size(
+        granule_list
+    )
+    api_request, dl_params = construct_request(
+        v,
+        short_name,
+        viirs_params["start_date"],
+        viirs_params["end_date"],
+        viirs_params["bbox"],
+        request_mode,
+        page_size,
+    )
+    if request_mode == "async":
+        dl_url = make_async_data_orders(page_num, api_session, dl_params)
+        print(dl_url)
+    else:
+        print("streaming mode")
+    print("Download Script Complete")

--- a/download.py
+++ b/download.py
@@ -2,7 +2,7 @@
 
 import requests
 import getpass
-import socket 
+import socket
 import json
 import zipfile
 import io
@@ -13,26 +13,95 @@ import pprint
 import re
 import time
 from requests.auth import HTTPBasicAuth
+from statistics import mean
 
 from luts import short_name
+from config import viirs_params
+
+# Class API session
+# version
+# is active
+# start / stop functions handle is_active state
+# make request
 
 
-# def start_api_session():
-#     """This function initates as NSDIC DAAC API session."""
-    
+def check_data_version(ds_short_name):
+    """Get latest version number of the dataset."""
+    cmr_collections_url = "https://cmr.earthdata.nasa.gov/search/collections.json"
+    response = requests.get(cmr_collections_url, params={"short_name": short_name})
+    results = json.loads(response.content)
 
-#     capability_url = f'https://n5eil02u.ecs.nsidc.org/egi/capabilities/{short_name}.{latest_version}.xml'
+    # find all instances of 'version_id' in metadata
+    versions = [el["version_id"] for el in results["feed"]["entry"]]
+    latest_version = max(versions)
+    return latest_version
 
-#     # Create session to store cookie and pass credentials to capabilities url
-#     session = requests.session()
-#     s = session.get(capability_url)
-#     response = session.get(s.url,auth=(uid,pswd))
-#     return response
 
-if __name__ == "__main__":
-    # Earthdata credentials
+def start_api_session(ds_short_name, ds_latest_version):
+    """Initate an authenticated NSDIC DAAC API session."""
     uid = input("Earthdata Login user name: ")
     pswd = getpass.getpass("Earthdata Login password: ")
-    #start_api_session()
+
+    capability_url = f"https://n5eil02u.ecs.nsidc.org/egi/capabilities/{ds_short_name}.{ds_latest_version}.xml"
+
+    # Create session to store cookie and pass credentials to capabilities url
+    session = requests.session()
+    s = session.get(capability_url)
+    response = session.get(s.url, auth=(uid, pswd))
+    return response
+
+
+def search_granules(ds_latest_version, ds_short_name, tstart, tstop, bbox):
+    """Search for granules within a time range and geographic bounding box. API reference: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#query-parameters"""
+    # Create CMR parameters used for granule search. Modify params depending on bounding_box or polygon input.
+
+    granule_search_url = "https://cmr.earthdata.nasa.gov/search/granules"
+    search_params = {
+        "short_name": ds_short_name,
+        "version": ds_latest_version,
+        "temporal": f"{tstart},{tstop}",
+        "page_size": 100,
+        "page_num": 1,
+        "bounding_box": bbox,
+    }
+
+    granules = []
+    headers = {"Accept": "application/json"}
+    while True:
+        response = requests.get(
+            granule_search_url, params=search_params, headers=headers
+        )
+        results = json.loads(response.content)
+        print(results)
+        if len(results["feed"]["entry"]) == 0:
+            # Out of results, so break out of loop
+            break
+
+        # Collect results and increment page_num
+        granules.extend(results["feed"]["entry"])
+        search_params["page_num"] += 1
+
+    print(
+        f"{len(granules)} granules of {ds_short_name} version {ds_latest_version} cover your area and time of interest."
+    )
+
+    granule_sizes = [float(granule["granule_size"]) for granule in granules]
+
+    print(
+        f"The average size of each granule is {mean(granule_sizes):.2f} MB and the total size of all {len(granules)} granules is {sum(granule_sizes):.2f} MB"
+    )
+
+
+if __name__ == "__main__":
+    v = check_data_version(short_name)
+    r = start_api_session(short_name, v)
+    print(r)
+    search_granules(
+        v,
+        short_name,
+        viirs_params["start_date"],
+        viirs_params["end_date"],
+        viirs_params["bbox"],
+    )
 
     base_request_url = f"https://n5eil02u.ecs.nsidc.org/egi/request?short_name=VNP10A1F&version=2&temporal=2013-01-01T00%3A00%3A00Z%2C2014-12-31T00%3A00%3A00Z&bounding_box=-146%2C64%2C-144%2C66&bbox=-146%2C64%2C-144%2C66&format=GeoTIFF&projection=GEOGRAPHIC&page_size=2000&request_mode=async&page_num=1"

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,38 @@
+name: viirs-snow
+channels:
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1=main
+  - _openmp_mutex=5.1=1_gnu
+  - brotli-python=1.0.9=py311h6a678d5_7
+  - bzip2=1.0.8=h7b6447c_0
+  - ca-certificates=2023.08.22=h06a4308_0
+  - certifi=2023.7.22=py311h06a4308_0
+  - cffi=1.15.1=py311h5eee18b_3
+  - charset-normalizer=2.0.4=pyhd3eb1b0_0
+  - cryptography=41.0.3=py311hdda0065_0
+  - idna=3.4=py311h06a4308_0
+  - ld_impl_linux-64=2.38=h1181459_1
+  - libffi=3.4.4=h6a678d5_0
+  - libgcc-ng=11.2.0=h1234567_1
+  - libgomp=11.2.0=h1234567_1
+  - libstdcxx-ng=11.2.0=h1234567_1
+  - libuuid=1.41.5=h5eee18b_0
+  - ncurses=6.4=h6a678d5_0
+  - openssl=3.0.12=h7f8727e_0
+  - pip=23.3=py311h06a4308_0
+  - pycparser=2.21=pyhd3eb1b0_0
+  - pyopenssl=23.2.0=py311h06a4308_0
+  - pysocks=1.7.1=py311h06a4308_0
+  - python=3.11.4=h955ad1f_0
+  - readline=8.2=h5eee18b_0
+  - requests=2.31.0=py311h06a4308_0
+  - setuptools=68.0.0=py311h06a4308_0
+  - sqlite=3.41.2=h5eee18b_0
+  - tk=8.6.12=h1ccaba5_0
+  - tzdata=2023c=h04d1e81_0
+  - urllib3=1.26.18=py311h06a4308_0
+  - wheel=0.41.2=py311h06a4308_0
+  - xz=5.4.2=h5eee18b_0
+  - zlib=1.2.13=h5eee18b_0
+prefix: /home/cparr4/miniconda3/envs/viirs-snow

--- a/luts.py
+++ b/luts.py
@@ -2,10 +2,15 @@
 
 short_name = "VNP10A1F"
 
-parameter_sets = {"dev_params": {"bbox": "-148,65,-147,66",
-              "start_date": "2015-01-01",
-              "end_date": "2016-12-31"},
-              "prod_params": {"bbox": "172,51,-130,72",
-              "start_date": "2012-01-01",
-              "end_date": "2022-12-31"}
+parameter_sets = {
+    "dev_params": {
+        "bbox": "-146,65,-145,66",
+        "start_date": "2013-01-01T00:00:00Z",
+        "end_date": "2014-12-31T23:00:00Z",
+    },
+    "prod_params": {
+        "bbox": "172,51,-130,72",
+        "start_date": "2012-01-01",
+        "end_date": "2022-12-31",
+    },
 }

--- a/luts.py
+++ b/luts.py
@@ -14,3 +14,20 @@ parameter_sets = {
         "end_date": "2022-12-31",
     },
 }
+
+# CP note: some of these could be remapped to a single int for NoData
+cgf_snow_cover_codes = {
+    **{i: "NDSI snow cover valid" for i in range(101)},
+    201: "No decision",
+    211: "Night",
+    237: "Lake / Inland water",
+    239: "Ocean",
+    250: "Cloud",
+    251: "Missing L1B data",
+    252: "L1B data failed calibration",
+    253: "Onboard VIIRS bowtie trim",
+    254: "L1B fill",
+    255: "L2 fill",
+}
+
+snow_cover_threshold = 50

--- a/luts.py
+++ b/luts.py
@@ -1,4 +1,4 @@
-"""Look-Up Tables for VIIRS Snow Metric Computations"""
+"""Look-Up Tables and Parameters for VIIRS Snow Metric Computations"""
 
 short_name = "VNP10A1F"
 
@@ -6,7 +6,7 @@ parameter_sets = {
     "dev_params": {
         "bbox": "-146,65,-145,66",
         "start_date": "2013-01-01T00:00:00Z",
-        "end_date": "2014-12-31T23:00:00Z",
+        "end_date": "2013-01-03T23:00:00Z",
     },
     "prod_params": {
         "bbox": "172,51,-130,72",

--- a/luts.py
+++ b/luts.py
@@ -6,12 +6,12 @@ parameter_sets = {
     "dev_params": {
         "bbox": "-146,65,-145,66",
         "start_date": "2013-01-01T00:00:00Z",
-        "end_date": "2013-01-03T23:00:00Z",
+        "end_date": "2013-01-03T23:59:59Z",
     },
     "prod_params": {
         "bbox": "172,51,-130,72",
-        "start_date": "2012-01-01",
-        "end_date": "2022-12-31",
+        "start_date": "2012-01-01T00:00:00Z",
+        "end_date": "2022-12-31T23:59:59Z",
     },
 }
 


### PR DESCRIPTION
To test this PR:

Clone this repository on Elephant and do the following:

```sh
export INPUT_DIR=/export/datadir/$USER/viirs_inputs
export SCRATCH_DIR=$HOME/VIIRS_snow_metrics/scratch
export OUTPUT_DIR=/$HOME/VIIRS_snow_metrics/outputs
export DEV_MODE=True
```
 - Sign up for an Earthdata account if you do not already have one, and note your user name and password.
 - Read instructions for `download.py` in the README
 - Run `python config.py` to observe DEV_MODE behavior and to verify that directory config is working as expected on Elephant.
 - Run `python download.py`

Observe behavior when `download.py` runs with an empty `$INPUT_DIR`.
Observe behavior when `download.py` runs with `$INPUT_DIR` already contains data.
Observe behavior when invalid API credentials are provided.

Examine the log file `download.log`
Examine the contents of `$INPUT_DIR` after the download is complete: `ls -lhrt $INPUT_DIR`

Test with a 3 day download window (edit `luts.py`)
Test with a 3 month download window (edit `luts.py`)
Test with downloading the full time series (`export DEV_MODE=False`)

